### PR TITLE
article: go timezone

### DIFF
--- a/articles/965393bd98cc35.md
+++ b/articles/965393bd98cc35.md
@@ -1,0 +1,117 @@
+---
+title: "Goの日時のParseの分かりづらいところ: タイムゾーン名を含む場合"
+emoji: "📑"
+type: "tech" # tech: 技術記事 / idea: アイデア
+topics: ["go", "golang"]
+published: true
+---
+
+## 本記事の概要
+Zennで読むことのできるGoの日時の扱いについては、@hsaki さんの記事が大変分かりやすいですよね。
+https://zenn.dev/hsaki/articles/go-time-cheatsheet
+
+こちらでも解説されてはいるのですが、混乱しやすいポイントだけに焦点を当てた記事も需要があるかな？と思い、私の頭の整理もかねて記事を書きます。
+
+本記事で着目するのは、「Parseする日時文字列にタイムゾーン名**だけ**(例：JST)がある時、得られる`time.Time`型の時間オフセットはどうなるか？」という点です。同じようにハマったことがある人は多いかな、と思うので、「あーあるある」ぐらいで読んでいただければと思います。
+
+## 本記事の対象読者
+- Goの基本的な日時の扱い方は知っている
+
+## 本記事の結論
+- タイムゾーン名だけでは時間オフセットは適切に設定されない。実行環境のタイムゾーンへの依存がある。
+- 解決策は環境変数`TZ`の設定か`ParseInLocation`を使うことだが、実行環境に必要なタイムゾーン情報(`tzdata`など)がないとエラーになるため、特にDocker等で使うような軽量なOSでは注意が必要。対処方法は本文参照。
+
+## Parse時のタイムゾーンの扱い
+さっそくですが、以下のコードを見てみましょう。
+
+```go
+package main
+
+func main(){
+    // なぞのフォーマット
+    s := "2023-09-16 09:00:00 JST"
+    format := "2006-01-02 15:04:05 MST"
+
+    t, _ := time.Parse(format, s)
+    fmt.Println(t)
+}
+```
+
+これを以下の環境で実行すると、どうなるでしょうか？
+
+```bash
+# 環境変数TZは未設定
+# システムのタイムゾーンはAsia/Tokyo
+
+go run main.go
+# Output: 2023-09-16 09:00:00 +0900 JST
+```
+
+はい、適切に世界標準時間から日本時間に変換されましたね。では、環境変数`TZ`を`UTC`に設定してみましょう。
+
+```bash
+TZ=UTC go run main.go
+# Output: 2023-09-16 09:00:00 +0000 JST
+```
+
+**タイムゾーンの名前はJSTですが、時間オフセットは+0000=UTC相当になってしまいました。** これは、`time.Parse`のドキュメントにも書かれた挙動ですが、ちょっとピンとこないですね。
+
+>When parsing a time with a zone abbreviation like MST, if the zone abbreviation has a defined offset in the current location, then that offset is used. The zone abbreviation "UTC" is recognized as UTC regardless of location. If the zone abbreviation is unknown, Parse records the time as being in a fabricated location with the given zone abbreviation and a zero offset. This choice means that such a time can be parsed and reformatted with the same layout losslessly, but the exact instant used in the representation will differ by the actual zone offset. To avoid such problems, prefer time layouts that use a numeric zone offset, or use ParseInLocation.
+
+Goでは実行環境のタイムゾーンを、環境変数`TZ`、`TZ`が未設定であればシステム設定から取得します。今回は`TZ`を上書きしたため、時刻文字列に含まれていた`JST`=`Asia/Tokyo`とアンマッチになり、タイムゾーン名だけが`JST`、オフセットは`+0000`になってしまったのですね。
+
+多様な実行環境を扱う現代では、`TZ`によりタイムゾーンを明示するか、あるいは次に示すように`time.ParseInLocation`を使う必要がありそうですね。ただ、この場合にも1点注意が必要なので、次にその点を見ていきましょう。
+
+## ロケーションを明示してParseする場合の注意点
+`time.ParseInLocation`を使うと、タイムゾーンを明示的に指定することができます。以下のコードを見てみましょう。
+
+```go
+package main
+
+func main() {
+    loc, _ := time.LoadLocation("Asia/Tokyo")
+    s := "2023-09-16 09:00:00 JST"
+    format := "2006-01-02 15:04:05 MST"
+
+    t, _ := time.ParseInLocation(format, s, loc)
+    fmt.Println(t)
+}
+```
+
+これを以下のように実行すると、どうなるでしょうか？
+
+```bash
+TZ=UTC go run main.go
+# Output: 2023-09-16 09:00:00 +0900 JST
+```
+
+はい、実行環境のローカルタイムに関わらず、タイムゾーンが`Asia/Tokyo`になりましたね。
+
+では上記のコードを`GOOS=linux`としてビルドし、ビルドしたファイルをDockerイメージの`alpine:latest`上で実行してみましょう。
+
+```bash
+GOOS=linux go build main.go -o tzplay
+
+# Dockerのもろもろは省略します
+
+# alpine:latest上での実行結果：
+# ./tzplay
+# panic: unknown time zone Asia/Tokyo
+```
+
+`time.LoadLocation`でエラーとなりました。Go1.15より前を経験した方には馴染みがあるかもしれませんが、これは実行環境にタイムゾーンの取得に必要な情報がないためです。
+
+こちらの解説が分かりやすいです。
+https://speakerdeck.com/hiroakis/go-false-timezone-to-go-1-dot-15-false-tzdata-mai-meip-mi?slide=23
+
+この課題はGo1.15で導入された`time/tzdata`パッケージにより解決されました。
+
+https://pkg.go.dev/time/tzdata
+
+`time/tzdata`をブランクインポートするか、ビルド時のオプションとして`-tags timetzdata`を指定することで、タイムゾーン情報を埋め込むことができます。その代償はビルドサイズで、上記ドキュメント内では450kB程度の増加が示唆されています。
+
+ちなみに先ほどのエラーは、`alpine:latest`環境に、環境変数`TZ=Asia/Tokyo`を指定した上で`time.Parse`を実行しても再現しますが、こちらも`time/tzdata`を埋め込むことで解決できます。
+
+## おわりに
+よいおさらいになりましたね！個人的にはこのあたりの挙動はちょっと不可解だなと思っていたので、改めて調べてみてよかったです。
+


### PR DESCRIPTION
Goで日時をパースする際に、JSTのようなタイムゾーン名を含む場合のハマりポイントがある。その解説記事。