### PR TITLE
article: go-timezone: refine examples to use Time.Format

### DIFF
--- a/articles/965393bd98cc35.md
+++ b/articles/965393bd98cc35.md
@@ -33,7 +33,7 @@ func main(){
     format := "2006-01-02 15:04:05 MST"
 
     t, _ := time.Parse(format, s)
-    fmt.Println(t)
+    fmt.Println(t.Format(time.RFC3339))
 }
 ```
 
@@ -44,20 +44,28 @@ func main(){
 # システムのタイムゾーンはAsia/Tokyo
 
 go run main.go
-# Output: 2023-09-16 09:00:00 +0900 JST
+# Output: 2023-09-16T09:00:00+09:00
 ```
 
-はい、適切に世界標準時間から日本時間に変換されましたね。では、環境変数`TZ`を`UTC`に設定してみましょう。
+はい、適切な日本時間として変換されましたね。では、環境変数`TZ`を`UTC`に設定してみましょう。
 
 ```bash
 TZ=UTC go run main.go
-# Output: 2023-09-16 09:00:00 +0000 JST
+# Output: 2023-09-16T09:00:00Z
 ```
 
-**タイムゾーンの名前はJSTですが、時間オフセットは+0000=UTC相当になってしまいました。** これは、`time.Parse`のドキュメントにも書かれた挙動ですが、ちょっとピンとこないですね。
+**時間オフセットがUTC相当になってしまいました。** これは、`time.Parse`のドキュメントにも書かれた挙動ですが、ちょっとピンとこないですね。
 
 >When parsing a time with a zone abbreviation like MST, if the zone abbreviation has a defined offset in the current location, then that offset is used. The zone abbreviation "UTC" is recognized as UTC regardless of location. If the zone abbreviation is unknown, Parse records the time as being in a fabricated location with the given zone abbreviation and a zero offset. This choice means that such a time can be parsed and reformatted with the same layout losslessly, but the exact instant used in the representation will differ by the actual zone offset. To avoid such problems, prefer time layouts that use a numeric zone offset, or use ParseInLocation.
 
+ちなみに、先ほどはParse後の`time.Time`をRFC3339にフォーマットして表示しましたが、`String()`の結果をみてみるとさらに混乱は深まります。
+
+```go
+    fmt.Println(t)
+    // Output: 2023-09-16 09:00:00 +0000 JST
+```
+
+JSTなのに+0000…？
 Goでは実行環境のタイムゾーンを、環境変数`TZ`、`TZ`が未設定であればシステム設定から取得します。今回は`TZ`を上書きしたため、時刻文字列に含まれていた`JST`=`Asia/Tokyo`とアンマッチになり、タイムゾーン名だけが`JST`、オフセットは`+0000`になってしまったのですね。
 
 多様な実行環境を扱う現代では、`TZ`によりタイムゾーンを明示するか、あるいは次に示すように`time.ParseInLocation`を使う必要がありそうですね。ただ、この場合にも1点注意が必要なので、次にその点を見ていきましょう。
@@ -74,7 +82,7 @@ func main() {
     format := "2006-01-02 15:04:05 MST"
 
     t, _ := time.ParseInLocation(format, s, loc)
-    fmt.Println(t)
+    fmt.Println(t.Format(time.RFC3339))
 }
 ```
 
@@ -82,10 +90,10 @@ func main() {
 
 ```bash
 TZ=UTC go run main.go
-# Output: 2023-09-16 09:00:00 +0900 JST
+# Output: 2023-09-16T09:00:00+09:00
 ```
 
-はい、実行環境のローカルタイムに関わらず、タイムゾーンが`Asia/Tokyo`になりましたね。
+はい、実行環境のローカルタイムに関わらず、`Asia/Tokyo`相当の時間になりましたね。
 
 では上記のコードを`GOOS=linux`としてビルドし、ビルドしたファイルをDockerイメージの`alpine:latest`上で実行してみましょう。
 


### PR DESCRIPTION
時間オフセットを適切に見せるために、time.Time.Format の結果を表示するように変更した。